### PR TITLE
cambios en el paginado

### DIFF
--- a/Client/src/Components/Pagination/Pagination.jsx
+++ b/Client/src/Components/Pagination/Pagination.jsx
@@ -5,6 +5,8 @@ import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import { Link } from "react-router-dom";
 
 const Pagination = ({ totalPages, currentPage, onPageChange }) => {
+  if (totalPages < 1) return null;
+
   return (
     <div className={styles.pageCntnr}>
       {currentPage !== 1 && (


### PR DESCRIPTION
se cambió que al no tener productos en en el home no se vea los botones del paginado y al cargar mas productos vaya detectando cuantas paginas y se muestre los botones